### PR TITLE
fix(design): make leaf deps optional peers for clean consumer typecheck

### DIFF
--- a/packages/design/package.json
+++ b/packages/design/package.json
@@ -52,8 +52,11 @@
     "test": "vitest run"
   },
   "peerDependencies": {
+    "@antfu/utils": "^9.0.0",
     "@axe-core/playwright": "^4.0.0",
+    "@iconify-json/catppuccin": "^1.0.0",
     "@tanstack/vue-virtual": "^3.0.0",
+    "colorjs.io": "^0.6.0",
     "floating-vue": "^5.0.0",
     "playwright": "^1.0.0",
     "reka-ui": "^2.0.0",
@@ -62,10 +65,19 @@
     "vue": "^3.5.0"
   },
   "peerDependenciesMeta": {
+    "@antfu/utils": {
+      "optional": true
+    },
     "@axe-core/playwright": {
       "optional": true
     },
+    "@iconify-json/catppuccin": {
+      "optional": true
+    },
     "@tanstack/vue-virtual": {
+      "optional": true
+    },
+    "colorjs.io": {
       "optional": true
     },
     "floating-vue": {
@@ -82,15 +94,14 @@
     }
   },
   "dependencies": {
-    "@antfu/utils": "catalog:inlined",
-    "@iconify-json/catppuccin": "catalog:frontend",
     "@unocss/core": "catalog:frontend",
-    "@vueuse/core": "catalog:frontend",
-    "colorjs.io": "catalog:frontend"
+    "@vueuse/core": "catalog:frontend"
   },
   "devDependencies": {
+    "@antfu/utils": "catalog:inlined",
     "@arethetypeswrong/cli": "catalog:testing",
     "@axe-core/playwright": "catalog:testing",
+    "@iconify-json/catppuccin": "catalog:frontend",
     "@storybook/vue3-vite": "catalog:storybook",
     "@tanstack/vue-virtual": "catalog:frontend",
     "@unocss/preset-icons": "catalog:frontend",
@@ -101,6 +112,7 @@
     "@unocss/transformer-directives": "catalog:frontend",
     "@vitejs/plugin-vue": "catalog:frontend",
     "@vue/test-utils": "catalog:testing",
+    "colorjs.io": "catalog:frontend",
     "floating-vue": "catalog:frontend",
     "happy-dom": "catalog:testing",
     "magic-string": "catalog:testing",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,28 +205,25 @@ importers:
 
   packages/design:
     dependencies:
-      '@antfu/utils':
-        specifier: catalog:inlined
-        version: 9.3.0
-      '@iconify-json/catppuccin':
-        specifier: catalog:frontend
-        version: 1.2.17
       '@unocss/core':
         specifier: catalog:frontend
         version: 66.7.2
       '@vueuse/core':
         specifier: catalog:frontend
         version: 14.3.0(vue@3.5.38(typescript@6.0.3))
-      colorjs.io:
-        specifier: catalog:frontend
-        version: 0.6.1
     devDependencies:
+      '@antfu/utils':
+        specifier: catalog:inlined
+        version: 9.3.0
       '@arethetypeswrong/cli':
         specifier: catalog:testing
         version: 0.18.4
       '@axe-core/playwright':
         specifier: catalog:testing
         version: 4.12.1(playwright-core@1.61.1)
+      '@iconify-json/catppuccin':
+        specifier: catalog:frontend
+        version: 1.2.17
       '@storybook/vue3-vite':
         specifier: catalog:storybook
         version: 10.4.6(esbuild@0.28.1)(storybook@10.4.6(@testing-library/dom@10.4.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(vite@8.1.0(@types/node@26.0.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
@@ -257,6 +254,9 @@ importers:
       '@vue/test-utils':
         specifier: catalog:testing
         version: 2.4.11(@vue/compiler-dom@3.5.39)(@vue/server-renderer@3.5.39(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))
+      colorjs.io:
+        specifier: catalog:frontend
+        version: 0.6.1
       floating-vue:
         specifier: catalog:frontend
         version: 5.2.2(vue@3.5.38(typescript@6.0.3))


### PR DESCRIPTION
Moves `@antfu/utils`, `colorjs.io`, and `@iconify-json/catppuccin` from `dependencies` to optional `peerDependencies` (kept as `devDependencies`), exactly mirroring the 0.2.0 treatment of the UI libs. As regular deps they nest under `@antfu/design` in pnpm's strict store and aren't resolvable when a consumer's `vue-tsc` typechecks a component `.vue` source (`Cannot find module '@antfu/utils'`, e.g. `DisplayDonut`); as peers they resolve from the consumer top level, unblocking clean component adoption. The package's own typecheck (passes), 93 tests (pass), and `pnpm peers check` (only the pre-existing unrelated `vue` mismatch) all verify the change. Note: since these are optional peers, adopters now install whichever they actually use — `@antfu/utils` for most components, `colorjs.io` for a11y/contrast, `@iconify-json/catppuccin` for icon data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)